### PR TITLE
Refactor Center and Card components in Login page

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -450,8 +450,19 @@ export default function Login() {
   };
 
   return (
-    <Center h="80vh" style={{ position: 'relative' }}>
-      <Card withBorder radius="md" p="xl" w={400}>
+    <Center
+      mih="100dvh"
+      px={{ base: 'md', sm: 0 }}
+      py={{ base: 'xl', sm: 0 }}
+      style={{ alignItems: 'center', position: 'relative' }}
+    >
+      <Card
+        withBorder
+        radius="md"
+        p={{ base: 'md', sm: 'xl' }}
+        w={{ base: '100%', sm: 400 }}
+        maw={400}
+      >
         <Stack gap="lg">
           <Group justify="space-between" align="center">
             <div style={{ flex: 1, display: 'flex', justifyContent: 'flex-start' }}>


### PR DESCRIPTION
<img width="1133" height="944" alt="Снимок экрана 2026-03-29 024009" src="https://github.com/user-attachments/assets/d372eaa7-3e41-4c63-b942-359d3e77c40b" />
шапка пропадает

после
<img width="1727" height="970" alt="Снимок экрана 2026-03-29 032740" src="https://github.com/user-attachments/assets/e08181f4-d89a-44bd-a969-099a858b2e2e" />

вы как автор, исправьте пожалуйста выравнивание отступов на всех устройствах 
